### PR TITLE
Adds support for throttling a release

### DIFF
--- a/custom-functions.php
+++ b/custom-functions.php
@@ -217,6 +217,10 @@ add_action( 'edd_after_customer_edit_link', 'eddwp_all_access_customer_card', 10
 
 function eddwp_all_access_payment_details( $payment_id ) {
 
+	if ( ! function_exists( 'edd_all_access_check' ) ) {
+		return;
+	}
+
 	$bundle_id      = eddwp_get_all_access_pass_id();
 	$customer_id    = edd_get_payment_customer_id( $payment_id );
 	$has_all_access = edd_all_access_check( array( 'customer_id' => $customer_id, 'download_id' => $bundle_id ) );
@@ -777,6 +781,7 @@ function pw_edd_auto_apply_discount() {
  * Include additional site functions
  */
 include( EDD_CUSTOM_FUNCTIONS . 'taxonomies.php' );
+include( EDD_CUSTOM_FUNCTIONS . 'software-licensing.php' );
 
 /**
  * Monster Insights - Google Optimize delay tweak

--- a/includes/software-licensing.php
+++ b/includes/software-licensing.php
@@ -68,7 +68,7 @@ class EDD_Custom_SL_Functionality {
 		$response['new_version']    = $found_item['version'];
 
 		$test_users[] = $identifier;
-		update_option( 'edd_rollout_' . $download->ID, $test_users );
+		update_option( 'edd_rollout_' . $download->ID, $test_users, false );
 
 		$package_url = edd_software_licensing()->get_encoded_download_package_url( $download->ID, $license_key, $url, false  );
 		$response['package']       = $package_url;

--- a/includes/software-licensing.php
+++ b/includes/software-licensing.php
@@ -25,6 +25,7 @@ class EDD_Custom_SL_Functionality {
 			return $response;
 		}
 
+		$test_users = array();
 		if ( empty( $download_beta ) ) {
 			$test_users = get_option( 'edd_rollout_' . $download->ID, true );
 		}

--- a/includes/software-licensing.php
+++ b/includes/software-licensing.php
@@ -62,12 +62,24 @@ class EDD_Custom_SL_Functionality {
 		$response['stable_version'] = $found_item['version'];
 		$response['new_version']    = $found_item['version'];
 
+		// Add this URL/License combination to the testing group.
 		$test_users[] = $identifier;
 		update_option( 'edd_rollout_' . $download->ID, array_unique( $test_users ), false );
 
+		// Define the package URL.
 		$package_url = edd_software_licensing()->get_encoded_download_package_url( $download->ID, $license_key, $url, false  );
 		$response['package']       = $package_url;
 		$response['download_link'] = $package_url;
+
+		// Setup the changelog.
+		$sections = maybe_unserialize( $response['sections'] );
+		if ( empty( $sections['changelog'] ) ) {
+			$sections['changelog'] = wpautop( $found_item['changelog'] );
+		} else {
+			$sections['changelog'] = wpautop( $found_item['changelog'] ) . $sections['changelog'];
+		}
+
+		$response['sections']  = serialize( $sections );
 
 		return $response;
 	}

--- a/includes/software-licensing.php
+++ b/includes/software-licensing.php
@@ -8,14 +8,9 @@ class EDD_Custom_SL_Functionality {
 			self::$instance = new EDD_Custom_SL_Functionality;
 		}
 
-		self::hooks();
-		self::filters();
+		self::$instance->filters();
 
 		return self::$instance;
-	}
-
-	private function hooks() {
-
 	}
 
 	private function filters() {

--- a/includes/software-licensing.php
+++ b/includes/software-licensing.php
@@ -1,0 +1,134 @@
+<?php
+
+class EDD_Custom_SL_Functionality {
+
+	private static $instance;
+	public static function instance() {
+		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof EDD_Custom_SL_Functionality ) ) {
+			self::$instance = new EDD_Custom_SL_Functionality;
+		}
+
+		self::hooks();
+		self::filters();
+
+		return self::$instance;
+	}
+
+	private function hooks() {
+
+	}
+
+	private function filters() {
+		add_filter( 'edd_sl_license_response', array( self::$instance, 'filter_get_version_response' ), 10, 3 );
+		add_filter( 'edd_sl_download_upgrade_file_key', array( self::$instance, 'filter_file_key' ), 10, 2 );
+	}
+
+	public function filter_get_version_response( $response, $download, $download_beta ) {
+		if ( $download_beta ) {
+			return $response;
+		}
+
+		$found_item = $this->detect_rollout( $download->ID );
+
+		if ( empty( $found_item['rollout_pct'] ) ) {
+			return $response;
+		}
+
+		$test_users = get_option( 'edd_rollout_' . $download->ID, true );
+		if ( ! is_array( $test_users ) ) {
+			$test_users = array();
+		}
+
+		if ( ! empty( $found_item['max_users'] ) && count( $test_users ) >= $found_item['max_users'] ) {
+			return $response;
+		}
+
+		$license_key = ! empty( $_REQUEST['license'] ) ? sanitize_text_field( $_REQUEST['license'] ) : false;
+		$url         = ! empty( $_REQUEST['url'] )     ? edd_software_licensing()->clean_site_url( $_REQUEST['url'] ) : false;
+		if ( false === $license_key || false === $url ) {
+			return $response;
+		}
+
+		$identifier = md5( $url . $license_key );
+		if ( ! in_array( $identifier, $test_users ) ) {
+			$random_value = rand( 1, 100 ); // Get this user's randomized string.
+			$test_group   = 100 - $found_item['rollout_pct']; // Determine the threshold in the 1-100 range that is the test group.
+
+			if ( $random_value <= $test_group ) {
+
+				// This user wasn't selected to be in the test group. Deliver the control package.
+				return $response;
+
+			}
+		}
+
+
+		// Yay! We've got a test user.
+		$response['stable_version'] = $found_item['version'];
+		$response['new_version']    = $found_item['version'];
+
+		$test_users[] = $identifier;
+		update_option( 'edd_rollout_' . $download->ID, $test_users );
+
+		$package_url = edd_software_licensing()->get_encoded_download_package_url( $download->ID, $license_key, $url, false  );
+		$response['package']       = $package_url;
+		$response['download_link'] = $package_url;
+
+		return $response;
+	}
+
+	public function filter_file_key( $file_key, $download ) {
+		$found_item = $this->detect_rollout( $download->ID );
+
+		if ( ! $found_item ) {
+			return $file_key;
+		}
+
+		$test_users = get_option( 'edd_rollout_' . $download->ID, true );
+		if ( ! is_array( $test_users ) ) {
+			$test_users = array();
+		}
+		if ( false === stristr( $_SERVER['REQUEST_URI'], 'edd-sl/package_download' ) ) {
+			$license_key = ! empty( $_REQUEST['license'] ) ? sanitize_text_field( $_REQUEST['license'] ) : false;
+			$url         = ! empty( $_REQUEST['url'] ) ? edd_software_licensing()->clean_site_url( $_REQUEST['url'] ) : false;
+			if ( false === $license_key || false === $url ) {
+				return $file_key;
+			}
+		} else {
+			$url_parts = parse_url( $_SERVER['REQUEST_URI'] );
+			$paths     = array_values( explode( '/', $url_parts['path'] ) );
+
+			$token  = end( $paths );
+			$values = explode( ':', base64_decode( $token ) );
+
+			if ( count( $values ) !== 6 ) {
+				wp_die( __( 'Invalid token supplied', 'edd_sl' ), __( 'Error', 'edd_sl' ), array( 'response' => 401 ) );
+			}
+
+			$license_key = $values[1];
+			$url         = str_replace( '@', ':', $values[4] );
+		}
+
+		$identifier = md5( $url . $license_key );
+		if ( ! in_array( $identifier, $test_users ) ) {
+			return $file_key;
+		}
+
+		return $found_item['file_id'];
+	}
+
+	private function detect_rollout( $download_id ) {
+		// If we don't have any rollouts defined, the array is empty, or the download being requested doesn't have a rollout, just move along.
+		if ( ! defined( 'EDD_ROLLOUT_PRODUCTS' ) || empty( EDD_ROLLOUT_PRODUCTS ) || ! array_key_exists( $download_id, EDD_ROLLOUT_PRODUCTS ) ) {
+			return false;
+		}
+
+		return EDD_ROLLOUT_PRODUCTS[ $download_id ];
+	}
+
+}
+
+function eddwp_custom_sl_functionality() {
+	return EDD_Custom_SL_Functionality::instance();
+}
+add_filter( 'plugins_loaded', 'eddwp_custom_sl_functionality', 20 );

--- a/includes/software-licensing.php
+++ b/includes/software-licensing.php
@@ -68,7 +68,7 @@ class EDD_Custom_SL_Functionality {
 		$response['new_version']    = $found_item['version'];
 
 		$test_users[] = $identifier;
-		update_option( 'edd_rollout_' . $download->ID, $test_users, false );
+		update_option( 'edd_rollout_' . $download->ID, array_unique( $test_users ), false );
 
 		$package_url = edd_software_licensing()->get_encoded_download_package_url( $download->ID, $license_key, $url, false  );
 		$response['package']       = $package_url;


### PR DESCRIPTION
Ok, so this is something that allows us to slowly roll out a large update. It works in conjunction with Software Licensing only give the release to a percentage of users as well as capping the total number of users that can get a release, basically allowing us to phase in a larger release like software Licensing 3.6.

Prior to beginning tests, be sure you are on `feature/throttled-release` of EDD Custom Functions (this repo), and `release/3.6` of Software Licensing (pull down latest).

To Test it:
1) Setup a licensed product. Upload _both_ files to the the download, and define the 'control' (or current stable version) as the file to deliver for updates in the software Licensing Section:
![image 2018-03-30 at 10 22 32 am](https://user-images.githubusercontent.com/1390124/38146823-83650ee6-3404-11e8-9f9c-5f93b90d8f55.png)

Notice that we're using the `master` version for the main release, with a file ID of `1`.
![screen shot 2018-03-30 at 10 30 12 am](https://user-images.githubusercontent.com/1390124/38147027-608c2d18-3405-11e8-9666-78f939be28e1.png)


2) In your `wp-config.php` define the new constant: `EDD_ROLLOUT_PRODUCTS`. The format of this constant is an array, which allows us to easily move this between environments, and quickly modify the status or add new rollouts:
```
define( 'EDD_ROLLOUT_PRODUCTS', array(
	91348 => array( // The array Key should be the download Id you want to phase a rollout for
		'max_users'   => 100, // The total number of users to allow into the 'test' group
		'rollout_pct' => 99, // The % of users who will get the update when get_version is called
		'file_id'     => 2, // This defines the file ID to deliver for the updates. You can see above that the 'test' file is ID 2.
		'version'     => '3.6', // This is the version of the test release.
		'changelog'   => 'Test Changelog', // This will be prepended to the changelog so that any user getting the test, will see proper changelog data for it.
	)
) );
```

For easy test I've just been using Postman to activate domains and run the `get_version` action.

When a site that checks `get_version` is opted into the 'test' group, they are added to an array of sites (md5 hash of domain and license key) which is saved as an option called `edd_rollout_<download_id>` where `<download_id>` is the product being tested. This ensures that ones a site and license combination qualifies for the phased rollout, they will always get it. It also allows us to know that when the request _for_ the file itself comes through we can match that they were chosen into the test group as well.