### PR TITLE
Exit early if there's no payment ID or customer ID #103

### DIFF
--- a/includes/extensions/all-access-functions.php
+++ b/includes/extensions/all-access-functions.php
@@ -277,14 +277,24 @@ function eddwp_all_access_customer_card( $customer ) {
 }
 add_action( 'edd_after_customer_edit_link', 'eddwp_all_access_customer_card', 10, 1 );
 
+/**
+ * Show if the customer has an active All Access Pass on the order record
+ *
+ * @param int $payment_id
+ */
 function eddwp_all_access_payment_details( $payment_id ) {
 
-	if ( ! function_exists( 'edd_all_access_check' ) ) {
+	if ( ! function_exists( 'edd_all_access_check' ) || empty( $payment_id ) ) {
 		return;
 	}
 
-	$bundle_id      = eddwp_get_aap_id();
-	$customer_id    = edd_get_payment_customer_id( $payment_id );
+	$bundle_id   = eddwp_get_aap_id();
+	$customer_id = edd_get_payment_customer_id( $payment_id );
+
+	if ( empty( $customer_id ) ) {
+		return;
+	}
+
 	$has_all_access = edd_all_access_check( array( 'customer_id' => $customer_id, 'download_id' => $bundle_id ) );
 
 	if ( $has_all_access['success'] ) {


### PR DESCRIPTION
See #103

1. Adds a docblock.
2. Exits early if `$payment_id` is empty or if `$customer_id` is empty.

@SDavisMedia This is against master branch - not sure if that's right. Feel free to adjust accordingly.

EDIT by Sean: changed the PR to be against `dev` instead of `master` to test on staging. Changed "Closes" to "See" in reference to the issue so that the issue doesn't close when this is merged into `dev`.