### PR TITLE
Adding pass_id to the check_licenese and activate_license endopint #118

### DIFF
--- a/includes/extensions/all-access-functions.php
+++ b/includes/extensions/all-access-functions.php
@@ -1,15 +1,43 @@
 <?php
-/*
+/**
  * all-access-functions.php
  */
 
-// Get the download ID of the All Access Pass
+ /**
+  * Return the post_id (download_id) of the Personal pass.
+  */
+function eddwp_get_pp_id() {
+	$pp = get_page_by_path( 'personal-pass', OBJECT, 'download' );
+	return $pp->ID;
+}
+
+ /**
+  * Return the post_id (download_id) of the Extended pass.
+  */
+function eddwp_get_ep_id() {
+	$ep = get_page_by_path( 'extended-pass', OBJECT, 'download' );
+	return $ep->ID;
+}
+
+ /**
+  * Return the post_id (download_id) of the Professional pass.
+  */
+function eddwp_get_propass_id() {
+	$propass = get_page_by_path( 'professional-pass', OBJECT, 'download' );
+	return $propass->ID;
+}
+
+ /**
+  * Return the post_id (download_id) of the All Access Pass.
+  */
 function eddwp_get_aap_id() {
 	$aap = get_page_by_path( 'all-access-pass', OBJECT, 'download' );
 	return $aap->ID;
 }
 
-// Get the download ID of the Lifetime All Access Pass
+ /**
+  * Return the post_id (download_id) of the Lifetime All Access Pass.
+  */
 function eddwp_get_laap_id() {
 	$laap = get_page_by_path( 'lifetime-all-access-pass', OBJECT, 'download' );
 	return $laap->ID;

--- a/includes/extensions/software-licensing-functions.php
+++ b/includes/extensions/software-licensing-functions.php
@@ -168,20 +168,22 @@ class EDD_Custom_SL_Functionality {
 
 		if ( ! empty( $license_id ) ) {
 			$license     = new EDD_SL_License( $license_id );
-			$download_id = absint( $license->download_id );
+			if ( ! empty( $license->ID ) ) {
+				$download_id = absint( $license->download_id );
 
-			if ( ! empty( $download_id ) ) {
-				$pass_ids = array(
-					eddwp_get_pp_id(),
-					eddwp_get_ep_id(),
-					eddwp_get_propass_id(),
-					eddwp_get_aap_id(),
-					eddwp_get_laap_id(),
-				);
+				if ( ! empty( $download_id ) ) {
+					$pass_ids = array(
+						eddwp_get_pp_id(),
+						eddwp_get_ep_id(),
+						eddwp_get_propass_id(),
+						eddwp_get_aap_id(),
+						eddwp_get_laap_id(),
+					);
 
-				if ( in_array( $download_id, $pass_ids, true ) ) {
-					$pass_id_key = array_search( $download_id, $pass_ids, true );
-					$pass_id     = $pass_ids[ $pass_id_key ];
+					if ( in_array( $download_id, $pass_ids, true ) ) {
+						$pass_id_key = array_search( $download_id, $pass_ids, true );
+						$pass_id     = $pass_ids[ $pass_id_key ];
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Resolves #118 

Included are:

- Add new functions for getting every pass level ID
- Improve doc blocks around pass ID getters
- Add `pass_id` to the `check_license` and `activate_license` responses
- Adjust the Custom SL functions to run later in the hook process on priority `99`